### PR TITLE
build: use Maven Central and Gradle Plugin Portal directly

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,7 +22,7 @@ pluginManagement {
     require(JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_21)) {
         "This build requires Gradle to be run with at least Java 21"
     }
-    repositories { maven("https://cache-redirector.jetbrains.com/plugins.gradle.org") }
+    repositories { gradlePluginPortal() }
 }
 
 plugins {
@@ -32,7 +32,7 @@ plugins {
 
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-    repositories { maven("https://cache-redirector.jetbrains.com/repo1.maven.org/maven2") }
+    repositories { mavenCentral() }
 }
 
 develocity {


### PR DESCRIPTION
## Summary
- Replace the JetBrains cache redirector with `gradlePluginPortal()` for plugin resolution and `mavenCentral()` for dependency resolution in `settings.gradle.kts`.

## Test plan
- [x] `./gradlew --refresh-dependencies help` resolves plugins and dependencies successfully against the new repositories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)