### PR TITLE
refactor: decouple sync engine, HTTP client, and metadata XML for testability

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     implementation(libs.ktor.client.auth)
     implementation(libs.ktor.client.logging)
     implementation(libs.kotlinx.coroutines)
+    implementation(libs.kotlinx.datetime)
 
     implementation(libs.oshai.kotlinLogging)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ ktfmt = { id = "com.ncorti.ktfmt.gradle", version = "0.26.0" }
 
 [libraries]
 kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.10.2" }
+kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.7.0" }
 oshai-kotlinLogging = { module = "io.github.oshai:kotlin-logging-jvm", version = "7.0.7" }
 pearx-kasechange = { module = "net.pearx.kasechange:kasechange-jvm", version = "1.4.1" }
 guava = { module = "com.google.guava:guava", version = "33.4.8-jre" }

--- a/src/main/kotlin/io/cloudshiftdev/mavensync/Clock.kt
+++ b/src/main/kotlin/io/cloudshiftdev/mavensync/Clock.kt
@@ -1,0 +1,22 @@
+package io.cloudshiftdev.mavensync
+
+import kotlin.time.Clock
+import kotlin.time.Instant
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.format.Padding
+import kotlinx.datetime.toLocalDateTime
+
+internal val SystemClock: Clock = Clock.System
+
+private val mavenLastUpdatedFormat = LocalDateTime.Format {
+    year(padding = Padding.ZERO)
+    monthNumber(padding = Padding.ZERO)
+    day(padding = Padding.ZERO)
+    hour(padding = Padding.ZERO)
+    minute(padding = Padding.ZERO)
+    second(padding = Padding.ZERO)
+}
+
+internal fun Instant.toMavenLastUpdated(): String =
+    mavenLastUpdatedFormat.format(this.toLocalDateTime(TimeZone.UTC))

--- a/src/main/kotlin/io/cloudshiftdev/mavensync/Extensions.kt
+++ b/src/main/kotlin/io/cloudshiftdev/mavensync/Extensions.kt
@@ -5,6 +5,9 @@ import io.ktor.http.*
 internal val Url.filename: Filename
     get() = Filename(encodedPath.substringAfterLast("/"))
 
+internal val Url.isDirectory: Boolean
+    get() = encodedPath.endsWith("/")
+
 internal fun String.normalizeUrlPath(): String {
     return when {
         endsWith('/') -> this

--- a/src/main/kotlin/io/cloudshiftdev/mavensync/HttpClientConfig.kt
+++ b/src/main/kotlin/io/cloudshiftdev/mavensync/HttpClientConfig.kt
@@ -1,0 +1,15 @@
+package io.cloudshiftdev.mavensync
+
+internal data class HttpClientConfig(
+    val logHttpHeaders: Boolean = false,
+    val requestTimeoutMs: Long = 45_000,
+    val connectTimeoutMs: Long = 3_000,
+    val socketTimeoutMs: Long = 45_000,
+    val userAgent: String = DEFAULT_USER_AGENT,
+    val trustAllCerts: Boolean = true,
+) {
+    companion object {
+        private const val DEFAULT_USER_AGENT: String =
+            "Gradle/8.7 (Mac OS X;15.1.1;aarch64) (Eclipse Adoptium;21.0.2;21.0.2+13-LTS)"
+    }
+}

--- a/src/main/kotlin/io/cloudshiftdev/mavensync/MavenHttpClient.kt
+++ b/src/main/kotlin/io/cloudshiftdev/mavensync/MavenHttpClient.kt
@@ -5,30 +5,26 @@ import com.fleeksoft.ksoup.parser.Parser
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.*
 import io.ktor.client.content.*
-import io.ktor.client.engine.*
-import io.ktor.client.engine.okhttp.*
 import io.ktor.client.plugins.*
-import io.ktor.client.plugins.auth.*
 import io.ktor.client.plugins.auth.providers.*
-import io.ktor.client.plugins.logging.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.util.cio.*
 import io.ktor.utils.io.*
-import io.ktor.utils.io.charsets.*
 import java.io.File
-import java.security.SecureRandom
-import java.security.cert.X509Certificate
-import javax.net.ssl.SSLContext
-import javax.net.ssl.X509TrustManager
 
 private val logger = KotlinLogging.logger {}
 
-internal class MavenHttpClient(logHttpHeaders: Boolean, credentials: BasicAuthCredentials?) :
-    AutoCloseable {
-    private val httpClient = HttpClientFactory.create(logHttpHeaders, credentials)
-    private val directoryListingParser = DirectoryListingParser.create()
+internal class MavenHttpClient(
+    private val httpClient: HttpClient,
+    private val directoryListingParser: DirectoryListingParser = DirectoryListingParser.create(),
+) : AutoCloseable {
+
+    constructor(
+        config: HttpClientConfig,
+        credentials: BasicAuthCredentials?,
+    ) : this(MavenHttpClientFactory.create(config, credentials))
 
     override fun close() {
         httpClient.close()
@@ -100,29 +96,6 @@ internal class MavenHttpClient(logHttpHeaders: Boolean, credentials: BasicAuthCr
     }
 }
 
-private class OkhttpEngineFactory : HttpClientEngineFactory<OkHttpConfig> {
-    override fun create(block: OkHttpConfig.() -> Unit): HttpClientEngine {
-        return OkHttp.create {
-            config {
-                followRedirects(false)
-                val sslContext = SSLContext.getInstance("TLS")
-                val trustAllCerts = TrustAllX509TrustManager()
-                sslContext.init(null, arrayOf(trustAllCerts), SecureRandom())
-                sslSocketFactory(sslContext.socketFactory, trustAllCerts)
-                hostnameVerifier { _, _ -> true }
-            }
-        }
-    }
-
-    private class TrustAllX509TrustManager : X509TrustManager {
-        override fun getAcceptedIssuers(): Array<X509Certificate?> = arrayOfNulls(0)
-
-        override fun checkClientTrusted(certs: Array<X509Certificate?>?, authType: String?) {}
-
-        override fun checkServerTrusted(certs: Array<X509Certificate?>?, authType: String?) {}
-    }
-}
-
 internal class MissingContentException(response: HttpResponse, cachedResponseText: String) :
     ResponseException(response, cachedResponseText) {
 
@@ -144,84 +117,4 @@ internal class MissingContentTypeException(response: HttpResponse) :
 
     override val message: String =
         "Missing content type(${response.call.request.method.value} ${response.call.request.url}"
-}
-
-private object HttpClientFactory {
-    fun create(logHttpHeaders: Boolean, credentials: BasicAuthCredentials?): HttpClient {
-        return HttpClient(OkhttpEngineFactory()) {
-            install(HttpTimeout) {
-                requestTimeoutMillis = 45000
-                connectTimeoutMillis = 3000
-                socketTimeoutMillis = 45000
-            }
-            install(Logging) {
-                this.logger = Logger.DEFAULT
-                level =
-                    when {
-                        logHttpHeaders -> LogLevel.HEADERS
-                        else -> LogLevel.NONE
-                    }
-                sanitizeHeader { header -> header == HttpHeaders.Authorization }
-            }
-
-            defaultRequest {
-                headers {
-                    append(
-                        "User-Agent",
-                        "Gradle/8.7 (Mac OS X;15.1.1;aarch64) (Eclipse Adoptium;21.0.2;21.0.2+13-LTS)",
-                    )
-                }
-            }
-
-            if (credentials != null) {
-                install(Auth) {
-                    basic {
-                        credentials {
-                            BasicAuthCredentials(
-                                username = credentials.username,
-                                password = credentials.password,
-                            )
-                        }
-                        realm = "Access to the maven repository"
-                        sendWithoutRequest { true }
-                    }
-                }
-            }
-
-            expectSuccess = true
-
-            HttpResponseValidator {
-                validateResponse { response ->
-                    suspend fun HttpResponse.exceptionText(): String {
-                        return try {
-                            bodyAsText()
-                        } catch (_: MalformedInputException) {
-                            "<body failed decoding>"
-                        }
-                    }
-
-                    when (response.status.value) {
-                        in 202..299 -> ResponseException(response, response.exceptionText())
-                    }
-                }
-
-                handleResponseExceptionWithRequest { exception, _ ->
-                    when (exception) {
-                        is ClientRequestException -> {
-                            when (exception.response.status.value) {
-                                404 ->
-                                    throw MissingContentException(
-                                        exception.response,
-                                        exception.message,
-                                    )
-
-                                409 ->
-                                    throw ConflictException(exception.response, exception.message)
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
 }

--- a/src/main/kotlin/io/cloudshiftdev/mavensync/MavenHttpClientFactory.kt
+++ b/src/main/kotlin/io/cloudshiftdev/mavensync/MavenHttpClientFactory.kt
@@ -1,0 +1,121 @@
+package io.cloudshiftdev.mavensync
+
+import io.ktor.client.*
+import io.ktor.client.engine.*
+import io.ktor.client.engine.okhttp.*
+import io.ktor.client.plugins.*
+import io.ktor.client.plugins.auth.*
+import io.ktor.client.plugins.auth.providers.*
+import io.ktor.client.plugins.logging.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.utils.io.charsets.*
+import java.security.SecureRandom
+import java.security.cert.X509Certificate
+import javax.net.ssl.SSLContext
+import javax.net.ssl.X509TrustManager
+
+internal object MavenHttpClientFactory {
+    fun create(
+        config: HttpClientConfig,
+        credentials: BasicAuthCredentials?,
+        engine: HttpClientEngineFactory<*>? = null,
+    ): HttpClient {
+        val resolvedEngine = engine ?: OkhttpEngineFactory(trustAllCerts = config.trustAllCerts)
+        return HttpClient(resolvedEngine) {
+            install(HttpTimeout) {
+                requestTimeoutMillis = config.requestTimeoutMs
+                connectTimeoutMillis = config.connectTimeoutMs
+                socketTimeoutMillis = config.socketTimeoutMs
+            }
+            install(Logging) {
+                this.logger = Logger.DEFAULT
+                level =
+                    when {
+                        config.logHttpHeaders -> LogLevel.HEADERS
+                        else -> LogLevel.NONE
+                    }
+                sanitizeHeader { header -> header == HttpHeaders.Authorization }
+            }
+
+            defaultRequest { headers { append("User-Agent", config.userAgent) } }
+
+            if (credentials != null) {
+                install(Auth) {
+                    basic {
+                        credentials {
+                            BasicAuthCredentials(
+                                username = credentials.username,
+                                password = credentials.password,
+                            )
+                        }
+                        realm = "Access to the maven repository"
+                        sendWithoutRequest { true }
+                    }
+                }
+            }
+
+            expectSuccess = true
+
+            HttpResponseValidator {
+                validateResponse { response ->
+                    suspend fun HttpResponse.exceptionText(): String {
+                        return try {
+                            bodyAsText()
+                        } catch (_: MalformedInputException) {
+                            "<body failed decoding>"
+                        }
+                    }
+
+                    when (response.status.value) {
+                        in 202..299 -> ResponseException(response, response.exceptionText())
+                    }
+                }
+
+                handleResponseExceptionWithRequest { exception, _ ->
+                    when (exception) {
+                        is ClientRequestException -> {
+                            when (exception.response.status.value) {
+                                404 ->
+                                    throw MissingContentException(
+                                        exception.response,
+                                        exception.message,
+                                    )
+
+                                409 ->
+                                    throw ConflictException(exception.response, exception.message)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private class OkhttpEngineFactory(private val trustAllCerts: Boolean) :
+    HttpClientEngineFactory<OkHttpConfig> {
+    override fun create(block: OkHttpConfig.() -> Unit): HttpClientEngine {
+        return OkHttp.create {
+            config {
+                followRedirects(false)
+                if (trustAllCerts) {
+                    val sslContext = SSLContext.getInstance("TLS")
+                    val trustManager = TrustAllX509TrustManager()
+                    sslContext.init(null, arrayOf(trustManager), SecureRandom())
+                    sslSocketFactory(sslContext.socketFactory, trustManager)
+                    hostnameVerifier { _, _ -> true }
+                }
+            }
+        }
+    }
+
+    private class TrustAllX509TrustManager : X509TrustManager {
+        override fun getAcceptedIssuers(): Array<X509Certificate?> = arrayOfNulls(0)
+
+        override fun checkClientTrusted(certs: Array<X509Certificate?>?, authType: String?) {}
+
+        override fun checkServerTrusted(certs: Array<X509Certificate?>?, authType: String?) {}
+    }
+}

--- a/src/main/kotlin/io/cloudshiftdev/mavensync/MavenHttpRepository.kt
+++ b/src/main/kotlin/io/cloudshiftdev/mavensync/MavenHttpRepository.kt
@@ -1,24 +1,18 @@
 package io.cloudshiftdev.mavensync
 
-import com.google.common.xml.XmlEscapers
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.plugins.auth.providers.*
 import io.ktor.http.*
 import java.nio.file.Path
+import kotlin.time.Clock
 import kotlin.time.Duration
-import kotlinx.coroutines.channels.SendChannel
-import kotlinx.coroutines.delay
-import org.apache.maven.artifact.versioning.DefaultArtifactVersion
+import kotlinx.coroutines.flow.Flow
 
 private val logger = KotlinLogging.logger {}
 
 internal interface MavenHttpRepository : AutoCloseable {
 
-    suspend fun crawlArtifactMetadata(
-        channel: SendChannel<ArtifactMetadata>,
-        crawlDelay: Duration,
-        paths: List<String>,
-    )
+    fun crawl(paths: List<String>, crawlDelay: Duration): Flow<ArtifactMetadata>
 
     suspend fun queryArtifactMetadata(group: Group, artifact: Artifact): ArtifactMetadata
 
@@ -39,52 +33,42 @@ internal interface MavenHttpRepository : AutoCloseable {
             url: String,
             credentials: RepositoryCredentials? = null,
             logHttpHeaders: Boolean = false,
+            trustAllCerts: Boolean = true,
+            clock: Clock = SystemClock,
         ): MavenHttpRepository {
-            val theBaseUrl =
-                when {
-                    url.endsWith("/") -> Url(url)
-                    else -> Url("$url/")
-                }
-            return DefaultMavenHttpRepository(theBaseUrl, credentials, logHttpHeaders)
+            val theBaseUrl = Url(url.normalizeUrlPath())
+            val httpClient =
+                MavenHttpClient(
+                    config =
+                        HttpClientConfig(
+                            logHttpHeaders = logHttpHeaders,
+                            trustAllCerts = trustAllCerts,
+                        ),
+                    credentials =
+                        credentials?.let { BasicAuthCredentials(it.username, it.password) },
+                )
+            return DefaultMavenHttpRepository(theBaseUrl, httpClient, clock)
         }
     }
 }
 
-private class DefaultMavenHttpRepository(
+internal class DefaultMavenHttpRepository(
     private val repoUrl: Url,
-    credentials: RepositoryCredentials?,
-    logHttpHeaders: Boolean,
+    private val mavenHttpClient: MavenHttpClient,
+    private val clock: Clock = SystemClock,
 ) : MavenHttpRepository {
-    private val mavenHttpClient =
-        MavenHttpClient(
-            logHttpHeaders,
-            credentials?.let { BasicAuthCredentials(it.username, it.password) },
-        )
+
+    private val crawler = MavenRepositoryCrawler(mavenHttpClient, repoUrl)
 
     override fun close() {
         mavenHttpClient.close()
     }
 
-    override suspend fun crawlArtifactMetadata(
-        channel: SendChannel<ArtifactMetadata>,
-        crawlDelay: Duration,
-        paths: List<String>,
-    ) {
-        if (paths.isEmpty()) {
-            crawlDirectoryListings(repoUrl, channel, crawlDelay)
-        } else {
-            paths.forEach { path ->
-                val startUrl =
-                    URLBuilder(repoUrl)
-                        .apply { appendPathSegments(path.normalizeUrlPath()) }
-                        .build()
-                crawlDirectoryListings(startUrl, channel, crawlDelay)
-            }
-        }
-    }
+    override fun crawl(paths: List<String>, crawlDelay: Duration): Flow<ArtifactMetadata> =
+        crawler.crawl(paths, crawlDelay)
 
     override suspend fun queryArtifactMetadata(group: Group, artifact: Artifact): ArtifactMetadata {
-        return readPossibleArtifactMetadata(metadataUrl(group, artifact))
+        return mavenHttpClient.fetchArtifactMetadata(metadataUrl(group, artifact))
             ?: ArtifactMetadata(group = group, artifact = artifact, artifactVersions = emptyList())
     }
 
@@ -131,111 +115,21 @@ private class DefaultMavenHttpRepository(
         val metadata = queryArtifactMetadata(coordinates.group, coordinates.artifact)
         val versions = metadata.artifactVersions + coordinates.artifactVersion
 
-        // update maven-metadata.xml with new version
-        val metadataXmlHolder =
+        val metadataXml =
             MavenMetadataXml(
                 group = coordinates.group.value,
                 artifactId = coordinates.artifact.value,
                 versions = versions.map { it.value },
-                lastUpdated = "20241224173330", // TODO
+                lastUpdated = clock.now().toMavenLastUpdated(),
                 latest = coordinates.artifactVersion.value,
                 release = coordinates.artifactVersion.value,
             )
 
-        val metadataXml = metadataXmlHolder.toXml()
-
-        // PUT maven-metadata.xml to target
-        mavenHttpClient.upload(metadataUrl(coordinates.group, coordinates.artifact), metadataXml)
+        mavenHttpClient.upload(
+            metadataUrl(coordinates.group, coordinates.artifact),
+            metadataXml.toXml(),
+        )
     }
-
-    private suspend fun crawlDirectoryListings(
-        url: Url,
-        channel: SendChannel<ArtifactMetadata>,
-        crawlDelay: Duration,
-    ) {
-        logger.info { "Reading index: $url" }
-        val childLinks = mavenHttpClient.parseDirectoryListing(url)
-
-        logger.debug { "Found ${childLinks.size} links in $url" }
-
-        val mavenMetadata =
-            childLinks
-                .firstOrNull { it.filename.value == MavenSpec.MavenMetadataXmlFile }
-                ?.let { readPossibleArtifactMetadata(it) }
-
-        // if there is a maven-metadata.xml in this directory, process it (when it represents
-        // versions)
-        if (mavenMetadata != null && mavenMetadata.artifactVersions.isNotEmpty()) {
-            logger.debug { "Found maven-metadata.xml in: $url" }
-            channel.send(mavenMetadata)
-            return
-        }
-
-        val dirs = childLinks.filter { it.isDirectory }
-        logger.debug { "Found ${dirs.size} directories in $url" }
-
-        // no maven-metadata; check if all directories are versions
-        if (dirs.isNotEmpty()) {
-            val versions = dirs.mapNotNull { artifactVersion(it.directoryName) }.sorted()
-            if (versions.size == dirs.size) {
-                logger.warn { "Missing maven-metadata.xml; synthesizing from versions: $url" }
-                // list of versions (no maven-metadata.xml); create metadata
-                val relativeUrl =
-                    url.segments
-                        .joinToString("/")
-                        .removePrefix(repoUrl.segments.joinToString("/"))
-                        .removeSuffix("/")
-                val artifact = relativeUrl.substringAfterLast("/")
-                val group = relativeUrl.substringBeforeLast("/").removePrefix("/").replace("/", ".")
-                val artifactMetadata =
-                    ArtifactMetadata(
-                        group = Group(group),
-                        artifact = Artifact(artifact),
-                        artifactVersions = versions.map { ArtifactVersion(it.toString()) },
-                    )
-                logger.debug { "Synthesized metadata: $artifactMetadata" }
-                channel.send(artifactMetadata)
-                return
-            }
-        }
-
-        // no maven-metadata.xml; recurse into directories
-        dirs.forEach {
-            delay(crawlDelay)
-            crawlDirectoryListings(it, channel, crawlDelay)
-        }
-    }
-
-    private suspend fun readPossibleArtifactMetadata(url: Url): ArtifactMetadata? {
-        val doc =
-            try {
-                mavenHttpClient.parseContent(url)
-            } catch (_: MissingContentException) {
-                null
-            } ?: return null
-
-        val groupId = doc.select("groupId").firstOrNull()
-        val artifactId = doc.select("artifactId").firstOrNull()
-        val artifactVersions =
-            doc.select("version").map { ArtifactVersion(it.text()) }.filterNot { it.isSnapshot }
-
-        val artifactMetadata =
-            ArtifactMetadata(
-                group = Group(groupId?.text() ?: error("Invalid group id: $doc")),
-                artifact = Artifact(artifactId?.text() ?: error("Invalid artifact id: $doc")),
-                artifactVersions = artifactVersions,
-            )
-        return artifactMetadata
-    }
-
-    private val Url.isDirectory: Boolean
-        get() = encodedPath.endsWith("/")
-
-    private val Url.directoryName: String
-        get() = encodedPath.removeSuffix("/").substringAfterLast("/")
-
-    private val Url.filename: Filename
-        get() = Filename(encodedPath.substringAfterLast("/"))
 
     private val Group.pathSegments: List<String>
         get() = value.split('.')
@@ -255,65 +149,4 @@ private class DefaultMavenHttpRepository(
             .appendPathSegments(group.pathSegments)
             .appendPathSegments(artifact.value, "maven-metadata.xml")
             .build()
-}
-
-/**
- * 2024-12-24T09:33:30.618-0800 [DEBUG] [org.apache.http.wire] http-outgoing-1 >> "<?xml
- * version="1.0" encoding="UTF-8"?>[\n]" 2024-12-24T09:33:30.618-0800 [DEBUG] [org.apache.http.wire]
- * http-outgoing-1 >> "<metadata>[\n]" 2024-12-24T09:33:30.618-0800 [DEBUG] [org.apache.http.wire]
- * http-outgoing-1 >> " <groupId>io.cloudshiftdev.foo</groupId>[\n]" 2024-12-24T09:33:30.618-0800
- * [DEBUG] [org.apache.http.wire] http-outgoing-1 >> " <artifactId>bar.baz</artifactId>[\n]"
- * 2024-12-24T09:33:30.618-0800 [DEBUG] [org.apache.http.wire] http-outgoing-1 >> "
- * <versioning>[\n]" 2024-12-24T09:33:30.618-0800 [DEBUG] [org.apache.http.wire] http-outgoing-1 >>
- * " <latest>1.2.5</latest>[\n]" 2024-12-24T09:33:30.618-0800 [DEBUG] [org.apache.http.wire]
- * http-outgoing-1 >> " <release>1.2.5</release>[\n]" 2024-12-24T09:33:30.618-0800 [DEBUG]
- * [org.apache.http.wire] http-outgoing-1 >> " <versions>[\n]" 2024-12-24T09:33:30.618-0800 [DEBUG]
- * [org.apache.http.wire] http-outgoing-1 >> " <version>1.2.3</version>[\n]"
- * 2024-12-24T09:33:30.618-0800 [DEBUG] [org.apache.http.wire] http-outgoing-1 >> "
- * <version>1.2.4</version>[\n]" 2024-12-24T09:33:30.618-0800 [DEBUG] [org.apache.http.wire]
- * http-outgoing-1 >> " <version>1.2.5</version>[\n]" 2024-12-24T09:33:30.618-0800 [DEBUG]
- * [org.apache.http.wire] http-outgoing-1 >> " </versions>[\n]" 2024-12-24T09:33:30.618-0800 [DEBUG]
- * [org.apache.http.wire] http-outgoing-1 >> " <lastUpdated>20241224173330</lastUpdated>[\n]"
- * 2024-12-24T09:33:30.618-0800 [DEBUG] [org.apache.http.wire] http-outgoing-1 >> "
- * </versioning>[\n]" 2024-12-24T09:33:30.618-0800 [DEBUG] [org.apache.http.wire] http-outgoing-1 >>
- * "</metadata>[\n]"
- */
-private data class MavenMetadataXml(
-    val group: String,
-    val artifactId: String,
-    val versions: List<String>,
-    val lastUpdated: String,
-    val latest: String,
-    val release: String,
-) {
-    fun toXml(): String {
-        val escaper = XmlEscapers.xmlContentEscaper()
-        return buildString(1024 + (100 * versions.size)) {
-            append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
-            append("<metadata>\n")
-            append("  <groupId>${escaper.escape(group)}</groupId>\n")
-            append("  <artifactId>${escaper.escape(artifactId)}</artifactId>\n")
-            append("  <versioning>\n")
-            append("    <latest>${escaper.escape(latest)}</latest>\n")
-            append("    <release>${escaper.escape(release)}</release>\n")
-            append("    <versions>\n")
-            versions.forEach { version ->
-                append("      <version>${escaper.escape(version)}</version>\n")
-            }
-            append("    </versions>\n")
-            append("    <lastUpdated>${escaper.escape(lastUpdated)}</lastUpdated>\n")
-            append("  </versioning>\n")
-            append("</metadata>\n")
-        }
-    }
-}
-
-internal fun artifactVersion(
-    version: String
-): org.apache.maven.artifact.versioning.ArtifactVersion? {
-    val parsedVersion = DefaultArtifactVersion(version)
-    return when {
-        parsedVersion.qualifier == version -> null
-        else -> parsedVersion
-    }
 }

--- a/src/main/kotlin/io/cloudshiftdev/mavensync/MavenMetadataXml.kt
+++ b/src/main/kotlin/io/cloudshiftdev/mavensync/MavenMetadataXml.kt
@@ -1,0 +1,33 @@
+package io.cloudshiftdev.mavensync
+
+import com.google.common.xml.XmlEscapers
+
+internal data class MavenMetadataXml(
+    val group: String,
+    val artifactId: String,
+    val versions: List<String>,
+    val lastUpdated: String,
+    val latest: String,
+    val release: String,
+) {
+    fun toXml(): String {
+        val escaper = XmlEscapers.xmlContentEscaper()
+        return buildString(1024 + (100 * versions.size)) {
+            append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
+            append("<metadata>\n")
+            append("  <groupId>${escaper.escape(group)}</groupId>\n")
+            append("  <artifactId>${escaper.escape(artifactId)}</artifactId>\n")
+            append("  <versioning>\n")
+            append("    <latest>${escaper.escape(latest)}</latest>\n")
+            append("    <release>${escaper.escape(release)}</release>\n")
+            append("    <versions>\n")
+            versions.forEach { version ->
+                append("      <version>${escaper.escape(version)}</version>\n")
+            }
+            append("    </versions>\n")
+            append("    <lastUpdated>${escaper.escape(lastUpdated)}</lastUpdated>\n")
+            append("  </versioning>\n")
+            append("</metadata>\n")
+        }
+    }
+}

--- a/src/main/kotlin/io/cloudshiftdev/mavensync/MavenMetadataXmlParser.kt
+++ b/src/main/kotlin/io/cloudshiftdev/mavensync/MavenMetadataXmlParser.kt
@@ -1,0 +1,29 @@
+package io.cloudshiftdev.mavensync
+
+import com.fleeksoft.ksoup.nodes.Document
+import io.ktor.http.Url
+
+internal object MavenMetadataXmlParser {
+    fun parse(doc: Document): ArtifactMetadata {
+        val groupId = doc.select("groupId").firstOrNull()
+        val artifactId = doc.select("artifactId").firstOrNull()
+        val artifactVersions =
+            doc.select("version").map { ArtifactVersion(it.text()) }.filterNot { it.isSnapshot }
+
+        return ArtifactMetadata(
+            group = Group(groupId?.text() ?: error("Invalid group id: $doc")),
+            artifact = Artifact(artifactId?.text() ?: error("Invalid artifact id: $doc")),
+            artifactVersions = artifactVersions,
+        )
+    }
+}
+
+internal suspend fun MavenHttpClient.fetchArtifactMetadata(url: Url): ArtifactMetadata? {
+    val doc =
+        try {
+            parseContent(url)
+        } catch (_: MissingContentException) {
+            return null
+        }
+    return MavenMetadataXmlParser.parse(doc)
+}

--- a/src/main/kotlin/io/cloudshiftdev/mavensync/MavenRepositoryCrawler.kt
+++ b/src/main/kotlin/io/cloudshiftdev/mavensync/MavenRepositoryCrawler.kt
@@ -1,0 +1,96 @@
+package io.cloudshiftdev.mavensync
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.http.*
+import kotlin.time.Duration
+import kotlinx.coroutines.channels.ProducerScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion
+
+private val logger = KotlinLogging.logger {}
+
+internal class MavenRepositoryCrawler(
+    private val httpClient: MavenHttpClient,
+    private val repoUrl: Url,
+) {
+    fun crawl(paths: List<String>, crawlDelay: Duration): Flow<ArtifactMetadata> = channelFlow {
+        if (paths.isEmpty()) {
+            crawlDirectoryListings(repoUrl, crawlDelay)
+        } else {
+            paths.forEach { path ->
+                val startUrl =
+                    URLBuilder(repoUrl)
+                        .apply { appendPathSegments(path.normalizeUrlPath()) }
+                        .build()
+                crawlDirectoryListings(startUrl, crawlDelay)
+            }
+        }
+    }
+
+    private suspend fun ProducerScope<ArtifactMetadata>.crawlDirectoryListings(
+        url: Url,
+        crawlDelay: Duration,
+    ) {
+        logger.info { "Reading index: $url" }
+        val childLinks = httpClient.parseDirectoryListing(url)
+
+        logger.debug { "Found ${childLinks.size} links in $url" }
+
+        val mavenMetadata =
+            childLinks
+                .firstOrNull { it.filename.value == MavenSpec.MavenMetadataXmlFile }
+                ?.let { httpClient.fetchArtifactMetadata(it) }
+
+        if (mavenMetadata != null && mavenMetadata.artifactVersions.isNotEmpty()) {
+            logger.debug { "Found maven-metadata.xml in: $url" }
+            channel.send(mavenMetadata)
+            return
+        }
+
+        val dirs = childLinks.filter { it.isDirectory }
+        logger.debug { "Found ${dirs.size} directories in $url" }
+
+        if (dirs.isNotEmpty()) {
+            val versions = dirs.mapNotNull { artifactVersion(it.directoryName) }.sorted()
+            if (versions.size == dirs.size) {
+                logger.warn { "Missing maven-metadata.xml; synthesizing from versions: $url" }
+                val relativeUrl =
+                    url.segments
+                        .joinToString("/")
+                        .removePrefix(repoUrl.segments.joinToString("/"))
+                        .removeSuffix("/")
+                val artifact = relativeUrl.substringAfterLast("/")
+                val group = relativeUrl.substringBeforeLast("/").removePrefix("/").replace("/", ".")
+                val artifactMetadata =
+                    ArtifactMetadata(
+                        group = Group(group),
+                        artifact = Artifact(artifact),
+                        artifactVersions = versions.map { ArtifactVersion(it.toString()) },
+                    )
+                logger.debug { "Synthesized metadata: $artifactMetadata" }
+                channel.send(artifactMetadata)
+                return
+            }
+        }
+
+        dirs.forEach {
+            delay(crawlDelay)
+            crawlDirectoryListings(it, crawlDelay)
+        }
+    }
+
+    private val Url.directoryName: String
+        get() = encodedPath.removeSuffix("/").substringAfterLast("/")
+}
+
+internal fun artifactVersion(
+    version: String
+): org.apache.maven.artifact.versioning.ArtifactVersion? {
+    val parsedVersion = DefaultArtifactVersion(version)
+    return when {
+        parsedVersion.qualifier == version -> null
+        else -> parsedVersion
+    }
+}

--- a/src/main/kotlin/io/cloudshiftdev/mavensync/MavenSyncEngine.kt
+++ b/src/main/kotlin/io/cloudshiftdev/mavensync/MavenSyncEngine.kt
@@ -1,0 +1,62 @@
+package io.cloudshiftdev.mavensync
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.consumeEach
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.produceIn
+import kotlinx.coroutines.launch
+
+private val logger = KotlinLogging.logger {}
+
+internal class MavenSyncEngine(
+    private val source: MavenHttpRepository,
+    private val target: MavenHttpRepository,
+    private val options: SyncOptions,
+) {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    suspend fun sync() = coroutineScope {
+        val artifactChannel =
+            source
+                .crawl(options.paths, options.crawlDelay)
+                .buffer(options.artifactConcurrency)
+                .produceIn(this)
+        repeat(options.artifactConcurrency) {
+            launch { artifactChannel.consumeEach { handleArtifact(it) } }
+        }
+    }
+
+    internal suspend fun handleArtifact(metadata: ArtifactMetadata) {
+        val targetMetadata = target.queryArtifactMetadata(metadata.group, metadata.artifact)
+        val sourceVersions = metadata.artifactVersions.toSet()
+        val targetVersions = targetMetadata.artifactVersions.toSet()
+        val missingVersions = sourceVersions - targetVersions
+        if (missingVersions.isEmpty()) {
+            logger.debug { "No missing versions for ${metadata.group}:${metadata.artifact}" }
+            return
+        }
+        logger.info {
+            "Syncing missing versions for ${metadata.group}:${metadata.artifact}: $missingVersions"
+        }
+        missingVersions
+            .map { Coordinates(metadata.group, metadata.artifact, it) }
+            .forEach { coordinates ->
+                val assets =
+                    source.listArtifactVersionAssets(
+                        coordinates,
+                        options.transferChecksums,
+                        options.transferSignatures,
+                    )
+
+                if (assets.isNotEmpty()) {
+                    assets.forEach { asset -> source.copyAsset(asset, target) }
+
+                    target.releaseVersion(coordinates)
+
+                    delay(options.downloadDelay)
+                }
+            }
+    }
+}

--- a/src/main/kotlin/io/cloudshiftdev/mavensync/MavenSyncMain.kt
+++ b/src/main/kotlin/io/cloudshiftdev/mavensync/MavenSyncMain.kt
@@ -12,17 +12,10 @@ import com.sksamuel.hoplite.sources.CommandLinePropertySource
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.io.File
 import kotlin.system.exitProcess
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.channels.consumeEach
-import kotlinx.coroutines.channels.produce
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import org.slf4j.LoggerFactory
 
 private val logger = KotlinLogging.logger {}
 
-@OptIn(ExperimentalCoroutinesApi::class)
 public suspend fun main(args: Array<String>) {
     if (args.contains("--debug")) {
         val loggerContext = LoggerFactory.getILoggerFactory() as LoggerContext
@@ -34,7 +27,11 @@ public suspend fun main(args: Array<String>) {
 
     logger.info { "Effective configuration: $config" }
 
-    executeSync(config)
+    config.source.toMavenHttpRepository().use { source ->
+        config.target.toMavenHttpRepository().use { target ->
+            MavenSyncEngine(source, target, config.toSyncOptions()).sync()
+        }
+    }
 }
 
 private fun loadConfiguration(args: Array<String>): SyncConfig =
@@ -53,98 +50,3 @@ private fun loadConfiguration(args: Array<String>): SyncConfig =
         logger.error(e) { "Error loading configuration" }
         exitProcess(1)
     }
-
-@OptIn(ExperimentalCoroutinesApi::class)
-private suspend fun executeSync(config: SyncConfig) {
-    config.target.toMavenHttpRepository().use { targetRepository ->
-        config.source.toMavenHttpRepository().use { sourceRepository ->
-            coroutineScope {
-                val artifactChannel =
-                    produce(capacity = config.artifactConcurrency) {
-                        sourceRepository.crawlArtifactMetadata(
-                            channel = this,
-                            crawlDelay = config.source.crawlDelay,
-                            paths = config.source.paths,
-                        )
-                    }
-                repeat(config.artifactConcurrency) {
-                    launch {
-                        artifactChannel.consumeEach { artifact ->
-                            handleArtifact(artifact, sourceRepository, targetRepository, config)
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-private fun RepositoryConfig.toMavenHttpRepository(): MavenHttpRepository {
-    return MavenHttpRepository.create(
-        url = url,
-        credentials = credentials,
-        logHttpHeaders = logHttpHeaders,
-    )
-}
-
-private suspend fun handleArtifact(
-    metadata: ArtifactMetadata,
-    sourceRepository: MavenHttpRepository,
-    targetRepository: MavenHttpRepository,
-    config: SyncConfig,
-) {
-    val targetMetadata = targetRepository.queryArtifactMetadata(metadata.group, metadata.artifact)
-    val sourceVersions = metadata.artifactVersions.toSet()
-    val targetVersions = targetMetadata.artifactVersions.toSet()
-    val missingVersions = sourceVersions - targetVersions
-    if (missingVersions.isEmpty())
-        return.also {
-            logger.debug { "No missing versions for ${metadata.group}:${metadata.artifact}" }
-        }
-    logger.info {
-        "Syncing missing versions for ${metadata.group}:${metadata.artifact}: $missingVersions"
-    }
-    missingVersions
-        .map { Coordinates(metadata.group, metadata.artifact, it) }
-        .forEach { coordinates ->
-
-            // find all assets for this version
-            val assets =
-                sourceRepository.listArtifactVersionAssets(
-                    coordinates,
-                    config.transferChecksums,
-                    config.transferSignatures,
-                )
-
-            if (assets.isNotEmpty()) {
-                // copy each asset to target
-                assets.forEach { asset -> sourceRepository.copyAsset(asset, targetRepository) }
-
-                targetRepository.releaseVersion(coordinates)
-
-                delay(config.source.downloadDelay)
-            }
-        }
-}
-
-internal data class Arg(
-    val names: List<String>,
-    val description: String,
-    val default: String? = null,
-    val required: Boolean = false,
-) {
-    companion object {
-        fun create(
-            name: String,
-            description: String,
-            default: String? = null,
-            required: Boolean = false,
-        ) = Arg(listOf(name), description, default, required)
-    }
-
-    fun toHelpText(): String {
-        val defaultText = if (default != null) " (default: $default)" else ""
-        val requiredText = if (required) " (required)" else ""
-        return names.joinToString(", ") + " : " + description + defaultText + requiredText
-    }
-}

--- a/src/main/kotlin/io/cloudshiftdev/mavensync/SyncConfig.kt
+++ b/src/main/kotlin/io/cloudshiftdev/mavensync/SyncConfig.kt
@@ -14,21 +14,32 @@ internal interface RepositoryConfig {
     val url: String
     val credentials: RepositoryCredentials?
     val logHttpHeaders: Boolean
+    val trustAllCerts: Boolean
 }
 
 internal data class TargetRepositoryConfig(
     override val url: String,
     override val credentials: RepositoryCredentials? = null,
     override val logHttpHeaders: Boolean,
+    override val trustAllCerts: Boolean,
 ) : RepositoryConfig
 
 internal data class SourceRepositoryConfig(
     override val url: String,
     override val credentials: RepositoryCredentials? = null,
     override val logHttpHeaders: Boolean,
+    override val trustAllCerts: Boolean,
     val crawlDelay: Duration,
     val downloadDelay: Duration,
     val paths: List<String>,
 ) : RepositoryConfig
 
 internal data class RepositoryCredentials(val username: String, val password: String)
+
+internal fun RepositoryConfig.toMavenHttpRepository(): MavenHttpRepository =
+    MavenHttpRepository.create(
+        url = url,
+        credentials = credentials,
+        logHttpHeaders = logHttpHeaders,
+        trustAllCerts = trustAllCerts,
+    )

--- a/src/main/kotlin/io/cloudshiftdev/mavensync/SyncOptions.kt
+++ b/src/main/kotlin/io/cloudshiftdev/mavensync/SyncOptions.kt
@@ -1,0 +1,22 @@
+package io.cloudshiftdev.mavensync
+
+import kotlin.time.Duration
+
+internal data class SyncOptions(
+    val transferChecksums: Boolean,
+    val transferSignatures: Boolean,
+    val artifactConcurrency: Int,
+    val crawlDelay: Duration,
+    val downloadDelay: Duration,
+    val paths: List<String>,
+)
+
+internal fun SyncConfig.toSyncOptions(): SyncOptions =
+    SyncOptions(
+        transferChecksums = transferChecksums,
+        transferSignatures = transferSignatures,
+        artifactConcurrency = artifactConcurrency,
+        crawlDelay = source.crawlDelay,
+        downloadDelay = source.downloadDelay,
+        paths = source.paths,
+    )

--- a/src/main/resources/config/defaults.json
+++ b/src/main/resources/config/defaults.json
@@ -4,11 +4,13 @@
   "artifactConcurrency" : 3,
   "source": {
     "logHttpHeaders" : false,
+    "trustAllCerts" : true,
     "crawlDelay": "100ms",
     "downloadDelay": "1s",
     "paths": []
   },
   "target": {
-    "logHttpHeaders" : false
+    "logHttpHeaders" : false,
+    "trustAllCerts" : true
   }
 }


### PR DESCRIPTION
## Summary
- Extract the sync algorithm into `MavenSyncEngine` taking injected source/target repositories and `SyncOptions`; move HTTP client construction into `MavenHttpClientFactory`/`HttpClientConfig` so an `HttpClient` (or test `MockEngine`) can be injected.
- Split `maven-metadata.xml` render/parse into `MavenMetadataXml` + `MavenMetadataXmlParser`, move the recursive crawl into `MavenRepositoryCrawler` exposing `Flow<ArtifactMetadata>`, and replace the hardcoded `lastUpdated` timestamp with a `kotlinx-datetime` `Clock` seam.
- Surface `trustAllCerts` in `RepositoryConfig` (defaulted to `true` to preserve current behavior); remove the unused `Arg` class. No external CLI/config schema changes; tests will land in a follow-up.

## Test plan
- [x] `CI=true ./gradlew build` (compile + ktfmt check + distZip)
- [ ] Smoke run against a real source/target repo to confirm crawl → copy → metadata upload still works and the new `lastUpdated` value is accepted by Maven clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)