### PR TITLE
test: add comprehensive unit test suite

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,6 +96,8 @@ testing {
                     implementation(platform(libs.kotest.bom))
                     implementation(libs.kotest.assertions.core)
                     implementation(libs.kotest.runner.junit5)
+                    implementation(platform(libs.ktor.bom))
+                    implementation(libs.ktor.client.mock)
                 }
                 targets {
                     all {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,3 +35,5 @@ ksoup-base = {module = "com.fleeksoft.ksoup:ksoup", version = "0.2.4" }
 kotest-bom = { module = "io.kotest:kotest-bom", version = "6.1.11" }
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core" }
 kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5" }
+
+ktor-client-mock = { module = "io.ktor:ktor-client-mock" }

--- a/src/test/kotlin/io/cloudshiftdev/mavensync/ClockTest.kt
+++ b/src/test/kotlin/io/cloudshiftdev/mavensync/ClockTest.kt
@@ -1,0 +1,20 @@
+package io.cloudshiftdev.mavensync
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlin.time.Instant
+
+class ClockTest :
+    FunSpec({
+        test("formats UTC instant as yyyyMMddHHmmss") {
+            Instant.parse("2024-03-15T08:30:45Z").toMavenLastUpdated() shouldBe "20240315083045"
+        }
+
+        test("zero-pads single-digit fields") {
+            Instant.parse("2001-01-02T03:04:05Z").toMavenLastUpdated() shouldBe "20010102030405"
+        }
+
+        test("uses UTC regardless of system zone") {
+            Instant.parse("2023-12-31T23:59:59Z").toMavenLastUpdated() shouldBe "20231231235959"
+        }
+    })

--- a/src/test/kotlin/io/cloudshiftdev/mavensync/DefaultMavenHttpRepositoryTest.kt
+++ b/src/test/kotlin/io/cloudshiftdev/mavensync/DefaultMavenHttpRepositoryTest.kt
@@ -1,0 +1,266 @@
+package io.cloudshiftdev.mavensync
+
+import com.fleeksoft.ksoup.nodes.Document
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockRequestHandleScope
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.ClientRequestException
+import io.ktor.client.plugins.HttpResponseValidator
+import io.ktor.client.request.HttpRequestData
+import io.ktor.client.request.HttpResponseData
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Url
+import io.ktor.http.content.TextContent
+import io.ktor.http.headersOf
+import kotlin.time.Clock
+import kotlin.time.Instant
+
+private val fixedClock =
+    object : Clock {
+        override fun now(): Instant = Instant.parse("2024-03-15T08:30:45Z")
+    }
+
+private const val REPO = "https://repo.example.com/maven2/"
+private const val METADATA_URL = "${REPO}com/example/foo/${MavenSpec.MavenMetadataXmlFile}"
+
+private class CannedListingParser(private val byUrl: Map<String, List<Url>>) :
+    DirectoryListingParser {
+    override suspend fun parse(url: Url, document: Document): List<Url> =
+        byUrl[url.toString()] ?: emptyList()
+}
+
+private fun MockRequestHandleScope.respondXml(body: String) =
+    respond(body, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, ContentType.Application.Xml.toString()))
+
+private fun MockRequestHandleScope.respondHtml(body: String = "<html><body><pre></pre></body></html>") =
+    respond(body, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, ContentType.Text.Html.toString()))
+
+private fun MockRequestHandleScope.respondNotFound() =
+    respond("not found", HttpStatusCode.NotFound, headersOf(HttpHeaders.ContentType, ContentType.Text.Plain.toString()))
+
+private fun buildHttpClient(
+    handler: suspend MockRequestHandleScope.(HttpRequestData) -> HttpResponseData
+): HttpClient {
+    return HttpClient(MockEngine) {
+        engine { addHandler { request -> handler(request) } }
+        expectSuccess = true
+        HttpResponseValidator {
+            handleResponseExceptionWithRequest { exception, _ ->
+                if (exception is ClientRequestException &&
+                    exception.response.status == HttpStatusCode.NotFound
+                ) {
+                    throw MissingContentException(exception.response, exception.message)
+                }
+            }
+        }
+    }
+}
+
+private fun metadataXml(versions: List<String>): String =
+    buildString {
+        append("<metadata><groupId>com.example</groupId><artifactId>foo</artifactId>")
+        append("<versioning><versions>")
+        versions.forEach { append("<version>$it</version>") }
+        append("</versions></versioning></metadata>")
+    }
+
+private fun HttpRequestData.bodyText(): String = (body as TextContent).text
+
+class DefaultMavenHttpRepositoryTest :
+    FunSpec({
+        val group = Group("com.example")
+        val artifact = Artifact("foo")
+
+        context("listArtifactVersionAssets") {
+            val coords = Coordinates(group, artifact, ArtifactVersion("1.0"))
+            val listingUrl = "${REPO}com/example/foo/1.0/"
+
+            val assets =
+                listOf(
+                    Url("${listingUrl}foo-1.0.jar"),
+                    Url("${listingUrl}foo-1.0.pom"),
+                    Url("${listingUrl}foo-1.0.jar.md5"),
+                    Url("${listingUrl}foo-1.0.jar.sha1"),
+                    Url("${listingUrl}foo-1.0.jar.asc"),
+                    Url("${listingUrl}other-1.0.jar"),
+                    Url("${listingUrl}subdir/"),
+                )
+
+            val mavenClient =
+                autoClose(
+                    MavenHttpClient(
+                        httpClient = buildHttpClient { _ -> respondHtml() },
+                        directoryListingParser = CannedListingParser(mapOf(listingUrl to assets)),
+                    )
+                )
+            val repo = DefaultMavenHttpRepository(Url(REPO), mavenClient, fixedClock)
+
+            test("excludes checksums and signatures by default") {
+                val result =
+                    repo.listArtifactVersionAssets(
+                        coords,
+                        includeChecksums = false,
+                        includeSignatures = false,
+                    )
+
+                result.map { it.name.value } shouldContainExactlyInAnyOrder
+                    listOf("foo-1.0.jar", "foo-1.0.pom")
+            }
+
+            test("includes signatures when includeSignatures is true") {
+                val result =
+                    repo.listArtifactVersionAssets(
+                        coords,
+                        includeChecksums = false,
+                        includeSignatures = true,
+                    )
+
+                result.map { it.name.value } shouldContainExactlyInAnyOrder
+                    listOf("foo-1.0.jar", "foo-1.0.pom", "foo-1.0.jar.asc")
+            }
+
+            test("includes checksums when includeChecksums is true") {
+                val result =
+                    repo.listArtifactVersionAssets(
+                        coords,
+                        includeChecksums = true,
+                        includeSignatures = false,
+                    )
+
+                result.map { it.name.value } shouldContainExactlyInAnyOrder
+                    listOf("foo-1.0.jar", "foo-1.0.pom", "foo-1.0.jar.md5", "foo-1.0.jar.sha1")
+            }
+        }
+
+        context("queryArtifactMetadata") {
+            test("returns empty metadata on 404") {
+                val mavenClient = autoClose(MavenHttpClient(buildHttpClient { _ -> respondNotFound() }))
+                val repo = DefaultMavenHttpRepository(Url(REPO), mavenClient, fixedClock)
+
+                val md = repo.queryArtifactMetadata(group, artifact)
+                md.group shouldBe group
+                md.artifact shouldBe artifact
+                md.artifactVersions shouldBe emptyList()
+            }
+
+            test("parses returned XML on 200") {
+                val mavenClient =
+                    autoClose(
+                        MavenHttpClient(buildHttpClient { _ -> respondXml(metadataXml(listOf("1.0", "1.1"))) })
+                    )
+                val repo = DefaultMavenHttpRepository(Url(REPO), mavenClient, fixedClock)
+
+                val md = repo.queryArtifactMetadata(group, artifact)
+                md.artifactVersions shouldBe
+                    listOf(ArtifactVersion("1.0"), ArtifactVersion("1.1"))
+            }
+        }
+
+        context("releaseVersion") {
+            test("uploads metadata XML containing existing + new version with deterministic timestamp") {
+                val coords = Coordinates(group, artifact, ArtifactVersion("2.0"))
+                val requests = mutableListOf<HttpRequestData>()
+
+                val mavenClient =
+                    autoClose(
+                        MavenHttpClient(
+                            buildHttpClient { request ->
+                                requests += request
+                                when (request.method) {
+                                    HttpMethod.Get -> respondXml(metadataXml(listOf("1.0")))
+                                    HttpMethod.Put -> respond("", HttpStatusCode.OK)
+                                    else -> respond("unexpected", HttpStatusCode.InternalServerError)
+                                }
+                            }
+                        )
+                    )
+                val repo = DefaultMavenHttpRepository(Url(REPO), mavenClient, fixedClock)
+
+                repo.releaseVersion(coords)
+
+                val put = requests.single { it.method == HttpMethod.Put }
+                put.url.toString() shouldBe METADATA_URL
+                put.bodyText() shouldBe
+                    MavenMetadataXml(
+                            group = "com.example",
+                            artifactId = "foo",
+                            versions = listOf("1.0", "2.0"),
+                            lastUpdated = "20240315083045",
+                            latest = "2.0",
+                            release = "2.0",
+                        )
+                        .toXml()
+            }
+
+            test("emits a version-only metadata when target has none yet") {
+                val coords = Coordinates(group, artifact, ArtifactVersion("1.0"))
+                val puts = mutableListOf<HttpRequestData>()
+
+                val mavenClient =
+                    autoClose(
+                        MavenHttpClient(
+                            buildHttpClient { request ->
+                                when (request.method) {
+                                    HttpMethod.Get -> respondNotFound()
+                                    HttpMethod.Put -> {
+                                        puts += request
+                                        respond("", HttpStatusCode.OK)
+                                    }
+                                    else -> respond("unexpected", HttpStatusCode.InternalServerError)
+                                }
+                            }
+                        )
+                    )
+                val repo = DefaultMavenHttpRepository(Url(REPO), mavenClient, fixedClock)
+
+                repo.releaseVersion(coords)
+
+                puts shouldHaveSize 1
+                puts.single().url.toString() shouldBe METADATA_URL
+                puts.single().bodyText() shouldBe
+                    MavenMetadataXml(
+                            group = "com.example",
+                            artifactId = "foo",
+                            versions = listOf("1.0"),
+                            lastUpdated = "20240315083045",
+                            latest = "1.0",
+                            release = "1.0",
+                        )
+                        .toXml()
+            }
+        }
+
+        context("URL construction") {
+            test("turns group dots into path segments") {
+                val deepGroup = Group("com.example.deep.module")
+                val coords = Coordinates(deepGroup, artifact, ArtifactVersion("1.0"))
+                val captured = mutableListOf<Url>()
+
+                val mavenClient =
+                    autoClose(
+                        MavenHttpClient(
+                            httpClient =
+                                buildHttpClient { request ->
+                                    captured += request.url
+                                    respondHtml()
+                                },
+                            directoryListingParser = CannedListingParser(emptyMap()),
+                        )
+                    )
+                val repo = DefaultMavenHttpRepository(Url(REPO), mavenClient, fixedClock)
+
+                repo.listArtifactVersionAssets(coords, includeChecksums = false, includeSignatures = false)
+
+                captured.single().toString() shouldBe
+                    "${REPO}com/example/deep/module/foo/1.0/"
+            }
+        }
+    })

--- a/src/test/kotlin/io/cloudshiftdev/mavensync/DirectoryListingParserTest.kt
+++ b/src/test/kotlin/io/cloudshiftdev/mavensync/DirectoryListingParserTest.kt
@@ -1,0 +1,67 @@
+package io.cloudshiftdev.mavensync
+
+import com.fleeksoft.ksoup.Ksoup
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.http.Url
+
+private const val BASE = "https://repo.example.com/com/example/"
+
+private fun listing(body: String) = Ksoup.parse("<html><body><pre>$body</pre></body></html>", BASE)
+
+class DirectoryListingParserTest :
+    FunSpec({
+        val parser = DirectoryListingParser.create()
+        val baseUrl = Url(BASE)
+
+        test("parses files and directories anchored to the base URL") {
+            val doc =
+                listing(
+                    "<a href=\"bar.jar\">bar.jar</a> 2024-01-01 12:00 1234\n" +
+                        "<a href=\"foo/\">foo/</a> 2024-01-01 12:00 -\n"
+                )
+
+            parser.parse(baseUrl, doc) shouldContainExactlyInAnyOrder
+                listOf(
+                    Url("${BASE}bar.jar"),
+                    Url("${BASE}foo/"),
+                )
+        }
+
+        test("filters out links not anchored to the base URL") {
+            val doc =
+                listing(
+                    "<a href=\"../\">parent/</a> 2024-01-01 12:00 -\n" +
+                        "<a href=\"https://other.example.com/x.jar\">x.jar</a> 2024-01-01 12:00 999\n" +
+                        "<a href=\"foo.jar\">foo.jar</a> 2024-01-01 12:00 999\n"
+                )
+
+            parser.parse(baseUrl, doc) shouldBe listOf(Url("${BASE}foo.jar"))
+        }
+
+        test("infers directory and adds trailing slash when href omits it") {
+            val doc =
+                listing("<a href=\"foo\">foo</a> 2024-01-01 12:00 -\n")
+
+            parser.parse(baseUrl, doc) shouldBe listOf(Url("${BASE}foo/"))
+        }
+
+        test("throws when listing text has the wrong number of pieces") {
+            val doc =
+                listing("<a href=\"foo.jar\">foo.jar</a> 2024-01-01 12:00\n")
+
+            val ex = shouldThrow<IllegalStateException> { parser.parse(baseUrl, doc) }
+            ex.cause shouldNotBe null
+            ex.cause.shouldBeInstanceOf<IllegalArgumentException>()
+        }
+
+        test("throws when there is no <pre> element") {
+            val doc = Ksoup.parse("<html><body><p>nothing here</p></body></html>", BASE)
+
+            shouldThrow<IllegalStateException> { parser.parse(baseUrl, doc) }
+        }
+    })

--- a/src/test/kotlin/io/cloudshiftdev/mavensync/ExtensionsTest.kt
+++ b/src/test/kotlin/io/cloudshiftdev/mavensync/ExtensionsTest.kt
@@ -1,0 +1,52 @@
+package io.cloudshiftdev.mavensync
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.http.Url
+
+class ExtensionsTest :
+    FunSpec({
+        context("Url.filename") {
+            test("returns last path segment") {
+                Url("https://repo.example.com/a/b/foo-1.0.jar").filename shouldBe Filename("foo-1.0.jar")
+            }
+
+            test("returns empty Filename for directory-style URL") {
+                Url("https://repo.example.com/a/b/").filename shouldBe Filename("")
+            }
+        }
+
+        context("Url.isDirectory") {
+            test("true when path ends with /") {
+                Url("https://repo.example.com/a/b/").isDirectory shouldBe true
+            }
+
+            test("false when path does not end with /") {
+                Url("https://repo.example.com/a/b/foo.jar").isDirectory shouldBe false
+            }
+        }
+
+        context("String.normalizeUrlPath") {
+            test("appends trailing slash when missing") {
+                "https://repo.example.com/a/b".normalizeUrlPath() shouldBe "https://repo.example.com/a/b/"
+            }
+
+            test("leaves trailing slash alone when present") {
+                "https://repo.example.com/a/b/".normalizeUrlPath() shouldBe "https://repo.example.com/a/b/"
+            }
+        }
+
+        context("List.groupPairs") {
+            test("pairs adjacent elements") {
+                listOf(1, 2, 3, 4).groupPairs() shouldBe listOf(1 to 2, 3 to 4)
+            }
+
+            test("drops trailing odd element") {
+                listOf(1, 2, 3).groupPairs() shouldBe listOf(1 to 2)
+            }
+
+            test("empty list yields empty list") {
+                emptyList<Int>().groupPairs() shouldBe emptyList()
+            }
+        }
+    })

--- a/src/test/kotlin/io/cloudshiftdev/mavensync/FakeMavenHttpRepository.kt
+++ b/src/test/kotlin/io/cloudshiftdev/mavensync/FakeMavenHttpRepository.kt
@@ -1,0 +1,53 @@
+package io.cloudshiftdev.mavensync
+
+import java.nio.file.Path
+import kotlin.time.Duration
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+
+internal class FakeMavenHttpRepository(private val label: String) : MavenHttpRepository {
+
+    val metadata = mutableMapOf<Pair<Group, Artifact>, ArtifactMetadata>()
+    val assets = mutableMapOf<Coordinates, List<ArtifactVersionAsset>>()
+
+    val listAssetCalls = mutableListOf<Triple<Coordinates, Boolean, Boolean>>()
+    val copyCalls = mutableListOf<Pair<ArtifactVersionAsset, MavenHttpRepository>>()
+    val uploadCalls = mutableListOf<Pair<ArtifactVersionAsset, Path>>()
+    val releaseCalls = mutableListOf<Coordinates>()
+
+    fun seedMetadata(md: ArtifactMetadata) {
+        metadata[md.group to md.artifact] = md
+    }
+
+    override fun crawl(paths: List<String>, crawlDelay: Duration): Flow<ArtifactMetadata> =
+        emptyFlow()
+
+    override suspend fun queryArtifactMetadata(group: Group, artifact: Artifact): ArtifactMetadata =
+        metadata[group to artifact]
+            ?: ArtifactMetadata(group = group, artifact = artifact, artifactVersions = emptyList())
+
+    override suspend fun listArtifactVersionAssets(
+        coordinates: Coordinates,
+        includeChecksums: Boolean,
+        includeSignatures: Boolean,
+    ): List<ArtifactVersionAsset> {
+        listAssetCalls += Triple(coordinates, includeChecksums, includeSignatures)
+        return assets[coordinates].orEmpty()
+    }
+
+    override suspend fun copyAsset(asset: ArtifactVersionAsset, targetRepository: MavenHttpRepository) {
+        copyCalls += asset to targetRepository
+    }
+
+    override suspend fun uploadAsset(asset: ArtifactVersionAsset, file: Path) {
+        uploadCalls += asset to file
+    }
+
+    override suspend fun releaseVersion(coordinates: Coordinates) {
+        releaseCalls += coordinates
+    }
+
+    override fun close() {}
+
+    override fun toString(): String = "FakeMavenHttpRepository($label)"
+}

--- a/src/test/kotlin/io/cloudshiftdev/mavensync/MavenMetadataXmlParserTest.kt
+++ b/src/test/kotlin/io/cloudshiftdev/mavensync/MavenMetadataXmlParserTest.kt
@@ -1,0 +1,97 @@
+package io.cloudshiftdev.mavensync
+
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.parser.Parser
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+private fun parseXml(xml: String) = Ksoup.parse(xml, parser = Parser.xmlParser())
+
+class MavenMetadataXmlParserTest :
+    FunSpec({
+        test("parses group, artifact, and release versions") {
+            val doc =
+                parseXml(
+                    """
+                    <metadata>
+                      <groupId>com.example</groupId>
+                      <artifactId>foo</artifactId>
+                      <versioning>
+                        <versions>
+                          <version>1.0</version>
+                          <version>1.1</version>
+                        </versions>
+                      </versioning>
+                    </metadata>
+                    """.trimIndent()
+                )
+
+            val md = MavenMetadataXmlParser.parse(doc)
+            md.group shouldBe Group("com.example")
+            md.artifact shouldBe Artifact("foo")
+            md.artifactVersions shouldBe listOf(ArtifactVersion("1.0"), ArtifactVersion("1.1"))
+        }
+
+        test("filters out SNAPSHOT versions") {
+            val doc =
+                parseXml(
+                    """
+                    <metadata>
+                      <groupId>com.example</groupId>
+                      <artifactId>foo</artifactId>
+                      <versioning>
+                        <versions>
+                          <version>1.0</version>
+                          <version>1.1-SNAPSHOT</version>
+                          <version>2.0</version>
+                        </versions>
+                      </versioning>
+                    </metadata>
+                    """.trimIndent()
+                )
+
+            MavenMetadataXmlParser.parse(doc).artifactVersions shouldBe
+                listOf(ArtifactVersion("1.0"), ArtifactVersion("2.0"))
+        }
+
+        test("throws when groupId missing") {
+            val doc =
+                parseXml(
+                    """
+                    <metadata>
+                      <artifactId>foo</artifactId>
+                    </metadata>
+                    """.trimIndent()
+                )
+
+            shouldThrow<IllegalStateException> { MavenMetadataXmlParser.parse(doc) }
+        }
+
+        test("throws when artifactId missing") {
+            val doc =
+                parseXml(
+                    """
+                    <metadata>
+                      <groupId>com.example</groupId>
+                    </metadata>
+                    """.trimIndent()
+                )
+
+            shouldThrow<IllegalStateException> { MavenMetadataXmlParser.parse(doc) }
+        }
+
+        test("returns empty version list when no <version> elements present") {
+            val doc =
+                parseXml(
+                    """
+                    <metadata>
+                      <groupId>com.example</groupId>
+                      <artifactId>foo</artifactId>
+                    </metadata>
+                    """.trimIndent()
+                )
+
+            MavenMetadataXmlParser.parse(doc).artifactVersions shouldBe emptyList()
+        }
+    })

--- a/src/test/kotlin/io/cloudshiftdev/mavensync/MavenMetadataXmlTest.kt
+++ b/src/test/kotlin/io/cloudshiftdev/mavensync/MavenMetadataXmlTest.kt
@@ -1,0 +1,74 @@
+package io.cloudshiftdev.mavensync
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+class MavenMetadataXmlTest :
+    FunSpec({
+        test("produces well-formed XML with all expected elements") {
+            val xml =
+                MavenMetadataXml(
+                        group = "com.example",
+                        artifactId = "foo",
+                        versions = listOf("1.0", "1.1", "2.0"),
+                        lastUpdated = "20240315083045",
+                        latest = "2.0",
+                        release = "2.0",
+                    )
+                    .toXml()
+
+            xml shouldBe
+                """
+                |<?xml version="1.0" encoding="UTF-8"?>
+                |<metadata>
+                |  <groupId>com.example</groupId>
+                |  <artifactId>foo</artifactId>
+                |  <versioning>
+                |    <latest>2.0</latest>
+                |    <release>2.0</release>
+                |    <versions>
+                |      <version>1.0</version>
+                |      <version>1.1</version>
+                |      <version>2.0</version>
+                |    </versions>
+                |    <lastUpdated>20240315083045</lastUpdated>
+                |  </versioning>
+                |</metadata>
+                |""".trimMargin()
+        }
+
+        test("emits empty <versions> block when no versions") {
+            val xml =
+                MavenMetadataXml(
+                        group = "com.example",
+                        artifactId = "foo",
+                        versions = emptyList(),
+                        lastUpdated = "20240315083045",
+                        latest = "1.0",
+                        release = "1.0",
+                    )
+                    .toXml()
+
+            xml shouldContain "    <versions>\n    </versions>\n"
+        }
+
+        test("escapes XML-special characters in values") {
+            val xml =
+                MavenMetadataXml(
+                        group = "com.<example>",
+                        artifactId = "foo&bar",
+                        versions = listOf("1.0<beta>"),
+                        lastUpdated = "20240315083045",
+                        latest = "1.0<beta>",
+                        release = "1.0<beta>",
+                    )
+                    .toXml()
+
+            xml shouldContain "<groupId>com.&lt;example&gt;</groupId>"
+            xml shouldContain "<artifactId>foo&amp;bar</artifactId>"
+            xml shouldContain "<version>1.0&lt;beta&gt;</version>"
+            xml shouldContain "<latest>1.0&lt;beta&gt;</latest>"
+            xml shouldContain "<release>1.0&lt;beta&gt;</release>"
+        }
+    })

--- a/src/test/kotlin/io/cloudshiftdev/mavensync/MavenRepositoryCrawlerTest.kt
+++ b/src/test/kotlin/io/cloudshiftdev/mavensync/MavenRepositoryCrawlerTest.kt
@@ -1,0 +1,27 @@
+package io.cloudshiftdev.mavensync
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+class MavenRepositoryCrawlerTest :
+    FunSpec({
+        context("artifactVersion") {
+            test("parses standard release versions") {
+                artifactVersion("1.0.0").shouldNotBeNull()
+                artifactVersion("2.4.1").shouldNotBeNull()
+            }
+
+            test("parses qualifier-bearing release versions") {
+                artifactVersion("1.0.0-RC1").shouldNotBeNull()
+                artifactVersion("1.0-beta").shouldNotBeNull()
+            }
+
+            test("returns null for non-version strings") {
+                // Maven's DefaultArtifactVersion treats unparseable input as pure qualifier,
+                // i.e. qualifier == input. The helper rejects those.
+                artifactVersion("foo") shouldBe null
+                artifactVersion("not-a-version") shouldBe null
+            }
+        }
+    })

--- a/src/test/kotlin/io/cloudshiftdev/mavensync/MavenSyncEngineTest.kt
+++ b/src/test/kotlin/io/cloudshiftdev/mavensync/MavenSyncEngineTest.kt
@@ -1,0 +1,102 @@
+package io.cloudshiftdev.mavensync
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import kotlin.time.Duration
+
+private fun defaultOptions(
+    transferChecksums: Boolean = false,
+    transferSignatures: Boolean = true,
+) = SyncOptions(
+    transferChecksums = transferChecksums,
+    transferSignatures = transferSignatures,
+    artifactConcurrency = 1,
+    crawlDelay = Duration.ZERO,
+    downloadDelay = Duration.ZERO,
+    paths = emptyList(),
+)
+
+private val group = Group("com.example")
+private val artifact = Artifact("foo")
+private fun coords(v: String) = Coordinates(group, artifact, ArtifactVersion(v))
+
+class MavenSyncEngineTest :
+    FunSpec({
+        test("does nothing when target already has all source versions") {
+            val source = FakeMavenHttpRepository("source")
+            val target = FakeMavenHttpRepository("target")
+            target.seedMetadata(
+                ArtifactMetadata(group, artifact, listOf(ArtifactVersion("1.0"), ArtifactVersion("1.1")))
+            )
+            val engine = MavenSyncEngine(source, target, defaultOptions())
+
+            engine.handleArtifact(
+                ArtifactMetadata(group, artifact, listOf(ArtifactVersion("1.0"), ArtifactVersion("1.1")))
+            )
+
+            source.listAssetCalls.shouldBeEmpty()
+            source.copyCalls.shouldBeEmpty()
+            target.releaseCalls.shouldBeEmpty()
+        }
+
+        test("copies missing versions and releases each one") {
+            val source = FakeMavenHttpRepository("source")
+            val target = FakeMavenHttpRepository("target")
+            target.seedMetadata(ArtifactMetadata(group, artifact, listOf(ArtifactVersion("1.0"))))
+
+            val v11 = coords("1.1")
+            val v20 = coords("2.0")
+            source.assets[v11] = listOf(ArtifactVersionAsset(v11, Filename("foo-1.1.jar")))
+            source.assets[v20] = listOf(ArtifactVersionAsset(v20, Filename("foo-2.0.jar")))
+
+            val engine = MavenSyncEngine(source, target, defaultOptions())
+
+            engine.handleArtifact(
+                ArtifactMetadata(
+                    group,
+                    artifact,
+                    listOf(ArtifactVersion("1.0"), ArtifactVersion("1.1"), ArtifactVersion("2.0")),
+                )
+            )
+
+            source.listAssetCalls.map { it.first } shouldContainExactlyInAnyOrder listOf(v11, v20)
+            source.copyCalls.map { (asset, repo) -> asset.coordinates to repo } shouldContainExactlyInAnyOrder
+                listOf(v11 to target, v20 to target)
+            target.releaseCalls shouldContainExactlyInAnyOrder listOf(v11, v20)
+        }
+
+        test("skips releaseVersion when listed assets are empty for a missing version") {
+            val source = FakeMavenHttpRepository("source")
+            val target = FakeMavenHttpRepository("target")
+            val v10 = coords("1.0")
+            source.assets[v10] = emptyList()
+
+            val engine = MavenSyncEngine(source, target, defaultOptions())
+
+            engine.handleArtifact(ArtifactMetadata(group, artifact, listOf(ArtifactVersion("1.0"))))
+
+            source.listAssetCalls.map { it.first } shouldContainExactly listOf(v10)
+            source.copyCalls.shouldBeEmpty()
+            target.releaseCalls.shouldBeEmpty()
+        }
+
+        test("passes transferChecksums and transferSignatures flags through to source") {
+            val source = FakeMavenHttpRepository("source")
+            val target = FakeMavenHttpRepository("target")
+            val v = coords("1.0")
+            source.assets[v] = listOf(ArtifactVersionAsset(v, Filename("foo-1.0.jar")))
+
+            val engine =
+                MavenSyncEngine(
+                    source,
+                    target,
+                    defaultOptions(transferChecksums = true, transferSignatures = false),
+                )
+
+            engine.handleArtifact(ArtifactMetadata(group, artifact, listOf(ArtifactVersion("1.0"))))
+
+            source.listAssetCalls shouldContainExactly listOf(Triple(v, true, false))
+        }
+    })

--- a/src/test/kotlin/io/cloudshiftdev/mavensync/SyncOptionsTest.kt
+++ b/src/test/kotlin/io/cloudshiftdev/mavensync/SyncOptionsTest.kt
@@ -1,0 +1,45 @@
+package io.cloudshiftdev.mavensync
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class SyncOptionsTest :
+    FunSpec({
+        test("SyncConfig.toSyncOptions maps every field") {
+            val config =
+                SyncConfig(
+                    transferChecksums = true,
+                    transferSignatures = false,
+                    artifactConcurrency = 7,
+                    source =
+                        SourceRepositoryConfig(
+                            url = "https://source.example.com/maven/",
+                            credentials = null,
+                            logHttpHeaders = false,
+                            trustAllCerts = true,
+                            crawlDelay = 250.milliseconds,
+                            downloadDelay = 2.seconds,
+                            paths = listOf("com/example", "org/other"),
+                        ),
+                    target =
+                        TargetRepositoryConfig(
+                            url = "https://target.example.com/maven/",
+                            credentials = null,
+                            logHttpHeaders = false,
+                            trustAllCerts = true,
+                        ),
+                )
+
+            config.toSyncOptions() shouldBe
+                SyncOptions(
+                    transferChecksums = true,
+                    transferSignatures = false,
+                    artifactConcurrency = 7,
+                    crawlDelay = 250.milliseconds,
+                    downloadDelay = 2.seconds,
+                    paths = listOf("com/example", "org/other"),
+                )
+        }
+    })

--- a/src/test/kotlin/io/cloudshiftdev/mavensync/TypesTest.kt
+++ b/src/test/kotlin/io/cloudshiftdev/mavensync/TypesTest.kt
@@ -1,0 +1,71 @@
+package io.cloudshiftdev.mavensync
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class TypesTest :
+    FunSpec({
+        context("Group") {
+            test("accepts a normal group id") {
+                Group("com.example").value shouldBe "com.example"
+                Group("com.example").toString() shouldBe "com.example"
+            }
+
+            test("rejects blank values") {
+                shouldThrow<IllegalArgumentException> { Group("") }
+                shouldThrow<IllegalArgumentException> { Group("   ") }
+            }
+
+            test("rejects values starting with a dot") {
+                shouldThrow<IllegalArgumentException> { Group(".com.example") }
+            }
+        }
+
+        context("ArtifactVersion.isSnapshot") {
+            test("true for -SNAPSHOT suffix") {
+                ArtifactVersion("1.0-SNAPSHOT").isSnapshot shouldBe true
+                ArtifactVersion("2.4.1-SNAPSHOT").isSnapshot shouldBe true
+            }
+
+            test("false for release versions") {
+                ArtifactVersion("1.0").isSnapshot shouldBe false
+                ArtifactVersion("1.0-RC1").isSnapshot shouldBe false
+                ArtifactVersion("1.0-snapshot").isSnapshot shouldBe false
+            }
+        }
+
+        context("Filename") {
+            test("extension returns the substring after the last dot") {
+                Filename("foo.jar").extension shouldBe "jar"
+                Filename("foo.tar.gz").extension shouldBe "gz"
+                Filename("noextension").extension shouldBe "noextension"
+            }
+
+            test("isPom") {
+                Filename("foo-1.0.pom").isPom shouldBe true
+                Filename("foo-1.0.jar").isPom shouldBe false
+            }
+
+            test("isChecksum covers md5/sha1/sha256/sha512") {
+                Filename("foo.jar.md5").isChecksum shouldBe true
+                Filename("foo.jar.sha1").isChecksum shouldBe true
+                Filename("foo.jar.sha256").isChecksum shouldBe true
+                Filename("foo.jar.sha512").isChecksum shouldBe true
+                Filename("foo.jar").isChecksum shouldBe false
+                Filename("foo.asc").isChecksum shouldBe false
+            }
+
+            test("isSignature for .asc") {
+                Filename("foo.jar.asc").isSignature shouldBe true
+                Filename("foo.jar").isSignature shouldBe false
+            }
+        }
+
+        context("Coordinates.toString") {
+            test("formats as group:artifact:version") {
+                Coordinates(Group("com.example"), Artifact("foo"), ArtifactVersion("1.0"))
+                    .toString() shouldBe "com.example:foo:1.0"
+            }
+        }
+    })


### PR DESCRIPTION
## Summary

- First test suite for the project. Adds Kotest FunSpec coverage across parsers, value types, the sync engine, and `DefaultMavenHttpRepository` (driven through Ktor `MockEngine` so HTTP behavior is exercised end-to-end inside the spec).
- Hand-rolled `FakeMavenHttpRepository` test double drives `MavenSyncEngine.handleArtifact` scenarios (version diff, asset copy, release, flag pass-through, empty-asset short-circuit).
- Adds `ktor-client-mock` as a test-only dependency in the version catalog and the test suite block.

## Test plan

- [x] `./gradlew test` — 49 tests pass
- [x] `./gradlew check` — clean