### PR TITLE
Fix CI: reformat test sources, order precommit, add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+# Maven Sync — Agent Notes
+
+## Pre-commit
+
+Run `./gradlew precommit` before every commit. It:
+
+1. Runs `ktfmtFormat` first, rewriting any non-conforming Kotlin source.
+2. Then runs `check` (compile, tests, and — in CI — `ktfmtCheck`).
+
+Ordering is enforced via `mustRunAfter` so formatting always lands before
+verification. CI sets `CI=true`, which disables `ktfmtFormat` and enables
+`ktfmtCheck`, so unformatted code committed locally will fail CI. See
+`build.gradle.kts` for the task wiring.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -129,8 +129,10 @@ val ciBuild = System.getenv("CI") != null
 val precommit =
     tasks.register("precommit") {
         group = "verification"
-        dependsOn("check", "ktfmtFormat")
+        dependsOn("ktfmtFormat", "check")
     }
+
+tasks.named("check") { mustRunAfter("ktfmtFormat") }
 
 // only check formatting for CI builds
 tasks.withType<KtfmtCheckTask>().configureEach { enabled = ciBuild }

--- a/src/test/kotlin/io/cloudshiftdev/mavensync/DefaultMavenHttpRepositoryTest.kt
+++ b/src/test/kotlin/io/cloudshiftdev/mavensync/DefaultMavenHttpRepositoryTest.kt
@@ -38,13 +38,27 @@ private class CannedListingParser(private val byUrl: Map<String, List<Url>>) :
 }
 
 private fun MockRequestHandleScope.respondXml(body: String) =
-    respond(body, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, ContentType.Application.Xml.toString()))
+    respond(
+        body,
+        HttpStatusCode.OK,
+        headersOf(HttpHeaders.ContentType, ContentType.Application.Xml.toString()),
+    )
 
-private fun MockRequestHandleScope.respondHtml(body: String = "<html><body><pre></pre></body></html>") =
-    respond(body, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, ContentType.Text.Html.toString()))
+private fun MockRequestHandleScope.respondHtml(
+    body: String = "<html><body><pre></pre></body></html>"
+) =
+    respond(
+        body,
+        HttpStatusCode.OK,
+        headersOf(HttpHeaders.ContentType, ContentType.Text.Html.toString()),
+    )
 
 private fun MockRequestHandleScope.respondNotFound() =
-    respond("not found", HttpStatusCode.NotFound, headersOf(HttpHeaders.ContentType, ContentType.Text.Plain.toString()))
+    respond(
+        "not found",
+        HttpStatusCode.NotFound,
+        headersOf(HttpHeaders.ContentType, ContentType.Text.Plain.toString()),
+    )
 
 private fun buildHttpClient(
     handler: suspend MockRequestHandleScope.(HttpRequestData) -> HttpResponseData
@@ -54,8 +68,9 @@ private fun buildHttpClient(
         expectSuccess = true
         HttpResponseValidator {
             handleResponseExceptionWithRequest { exception, _ ->
-                if (exception is ClientRequestException &&
-                    exception.response.status == HttpStatusCode.NotFound
+                if (
+                    exception is ClientRequestException &&
+                        exception.response.status == HttpStatusCode.NotFound
                 ) {
                     throw MissingContentException(exception.response, exception.message)
                 }
@@ -64,13 +79,12 @@ private fun buildHttpClient(
     }
 }
 
-private fun metadataXml(versions: List<String>): String =
-    buildString {
-        append("<metadata><groupId>com.example</groupId><artifactId>foo</artifactId>")
-        append("<versioning><versions>")
-        versions.forEach { append("<version>$it</version>") }
-        append("</versions></versioning></metadata>")
-    }
+private fun metadataXml(versions: List<String>): String = buildString {
+    append("<metadata><groupId>com.example</groupId><artifactId>foo</artifactId>")
+    append("<versioning><versions>")
+    versions.forEach { append("<version>$it</version>") }
+    append("</versions></versioning></metadata>")
+}
 
 private fun HttpRequestData.bodyText(): String = (body as TextContent).text
 
@@ -142,7 +156,8 @@ class DefaultMavenHttpRepositoryTest :
 
         context("queryArtifactMetadata") {
             test("returns empty metadata on 404") {
-                val mavenClient = autoClose(MavenHttpClient(buildHttpClient { _ -> respondNotFound() }))
+                val mavenClient =
+                    autoClose(MavenHttpClient(buildHttpClient { _ -> respondNotFound() }))
                 val repo = DefaultMavenHttpRepository(Url(REPO), mavenClient, fixedClock)
 
                 val md = repo.queryArtifactMetadata(group, artifact)
@@ -154,18 +169,21 @@ class DefaultMavenHttpRepositoryTest :
             test("parses returned XML on 200") {
                 val mavenClient =
                     autoClose(
-                        MavenHttpClient(buildHttpClient { _ -> respondXml(metadataXml(listOf("1.0", "1.1"))) })
+                        MavenHttpClient(
+                            buildHttpClient { _ -> respondXml(metadataXml(listOf("1.0", "1.1"))) }
+                        )
                     )
                 val repo = DefaultMavenHttpRepository(Url(REPO), mavenClient, fixedClock)
 
                 val md = repo.queryArtifactMetadata(group, artifact)
-                md.artifactVersions shouldBe
-                    listOf(ArtifactVersion("1.0"), ArtifactVersion("1.1"))
+                md.artifactVersions shouldBe listOf(ArtifactVersion("1.0"), ArtifactVersion("1.1"))
             }
         }
 
         context("releaseVersion") {
-            test("uploads metadata XML containing existing + new version with deterministic timestamp") {
+            test(
+                "uploads metadata XML containing existing + new version with deterministic timestamp"
+            ) {
                 val coords = Coordinates(group, artifact, ArtifactVersion("2.0"))
                 val requests = mutableListOf<HttpRequestData>()
 
@@ -177,7 +195,8 @@ class DefaultMavenHttpRepositoryTest :
                                 when (request.method) {
                                     HttpMethod.Get -> respondXml(metadataXml(listOf("1.0")))
                                     HttpMethod.Put -> respond("", HttpStatusCode.OK)
-                                    else -> respond("unexpected", HttpStatusCode.InternalServerError)
+                                    else ->
+                                        respond("unexpected", HttpStatusCode.InternalServerError)
                                 }
                             }
                         )
@@ -214,7 +233,8 @@ class DefaultMavenHttpRepositoryTest :
                                         puts += request
                                         respond("", HttpStatusCode.OK)
                                     }
-                                    else -> respond("unexpected", HttpStatusCode.InternalServerError)
+                                    else ->
+                                        respond("unexpected", HttpStatusCode.InternalServerError)
                                 }
                             }
                         )
@@ -257,10 +277,13 @@ class DefaultMavenHttpRepositoryTest :
                     )
                 val repo = DefaultMavenHttpRepository(Url(REPO), mavenClient, fixedClock)
 
-                repo.listArtifactVersionAssets(coords, includeChecksums = false, includeSignatures = false)
+                repo.listArtifactVersionAssets(
+                    coords,
+                    includeChecksums = false,
+                    includeSignatures = false,
+                )
 
-                captured.single().toString() shouldBe
-                    "${REPO}com/example/deep/module/foo/1.0/"
+                captured.single().toString() shouldBe "${REPO}com/example/deep/module/foo/1.0/"
             }
         }
     })

--- a/src/test/kotlin/io/cloudshiftdev/mavensync/DirectoryListingParserTest.kt
+++ b/src/test/kotlin/io/cloudshiftdev/mavensync/DirectoryListingParserTest.kt
@@ -26,10 +26,7 @@ class DirectoryListingParserTest :
                 )
 
             parser.parse(baseUrl, doc) shouldContainExactlyInAnyOrder
-                listOf(
-                    Url("${BASE}bar.jar"),
-                    Url("${BASE}foo/"),
-                )
+                listOf(Url("${BASE}bar.jar"), Url("${BASE}foo/"))
         }
 
         test("filters out links not anchored to the base URL") {
@@ -44,15 +41,13 @@ class DirectoryListingParserTest :
         }
 
         test("infers directory and adds trailing slash when href omits it") {
-            val doc =
-                listing("<a href=\"foo\">foo</a> 2024-01-01 12:00 -\n")
+            val doc = listing("<a href=\"foo\">foo</a> 2024-01-01 12:00 -\n")
 
             parser.parse(baseUrl, doc) shouldBe listOf(Url("${BASE}foo/"))
         }
 
         test("throws when listing text has the wrong number of pieces") {
-            val doc =
-                listing("<a href=\"foo.jar\">foo.jar</a> 2024-01-01 12:00\n")
+            val doc = listing("<a href=\"foo.jar\">foo.jar</a> 2024-01-01 12:00\n")
 
             val ex = shouldThrow<IllegalStateException> { parser.parse(baseUrl, doc) }
             ex.cause shouldNotBe null

--- a/src/test/kotlin/io/cloudshiftdev/mavensync/ExtensionsTest.kt
+++ b/src/test/kotlin/io/cloudshiftdev/mavensync/ExtensionsTest.kt
@@ -8,7 +8,8 @@ class ExtensionsTest :
     FunSpec({
         context("Url.filename") {
             test("returns last path segment") {
-                Url("https://repo.example.com/a/b/foo-1.0.jar").filename shouldBe Filename("foo-1.0.jar")
+                Url("https://repo.example.com/a/b/foo-1.0.jar").filename shouldBe
+                    Filename("foo-1.0.jar")
             }
 
             test("returns empty Filename for directory-style URL") {
@@ -28,11 +29,13 @@ class ExtensionsTest :
 
         context("String.normalizeUrlPath") {
             test("appends trailing slash when missing") {
-                "https://repo.example.com/a/b".normalizeUrlPath() shouldBe "https://repo.example.com/a/b/"
+                "https://repo.example.com/a/b".normalizeUrlPath() shouldBe
+                    "https://repo.example.com/a/b/"
             }
 
             test("leaves trailing slash alone when present") {
-                "https://repo.example.com/a/b/".normalizeUrlPath() shouldBe "https://repo.example.com/a/b/"
+                "https://repo.example.com/a/b/".normalizeUrlPath() shouldBe
+                    "https://repo.example.com/a/b/"
             }
         }
 

--- a/src/test/kotlin/io/cloudshiftdev/mavensync/FakeMavenHttpRepository.kt
+++ b/src/test/kotlin/io/cloudshiftdev/mavensync/FakeMavenHttpRepository.kt
@@ -35,7 +35,10 @@ internal class FakeMavenHttpRepository(private val label: String) : MavenHttpRep
         return assets[coordinates].orEmpty()
     }
 
-    override suspend fun copyAsset(asset: ArtifactVersionAsset, targetRepository: MavenHttpRepository) {
+    override suspend fun copyAsset(
+        asset: ArtifactVersionAsset,
+        targetRepository: MavenHttpRepository,
+    ) {
         copyCalls += asset to targetRepository
     }
 

--- a/src/test/kotlin/io/cloudshiftdev/mavensync/MavenMetadataXmlParserTest.kt
+++ b/src/test/kotlin/io/cloudshiftdev/mavensync/MavenMetadataXmlParserTest.kt
@@ -24,7 +24,8 @@ class MavenMetadataXmlParserTest :
                         </versions>
                       </versioning>
                     </metadata>
-                    """.trimIndent()
+                    """
+                        .trimIndent()
                 )
 
             val md = MavenMetadataXmlParser.parse(doc)
@@ -48,7 +49,8 @@ class MavenMetadataXmlParserTest :
                         </versions>
                       </versioning>
                     </metadata>
-                    """.trimIndent()
+                    """
+                        .trimIndent()
                 )
 
             MavenMetadataXmlParser.parse(doc).artifactVersions shouldBe
@@ -62,7 +64,8 @@ class MavenMetadataXmlParserTest :
                     <metadata>
                       <artifactId>foo</artifactId>
                     </metadata>
-                    """.trimIndent()
+                    """
+                        .trimIndent()
                 )
 
             shouldThrow<IllegalStateException> { MavenMetadataXmlParser.parse(doc) }
@@ -75,7 +78,8 @@ class MavenMetadataXmlParserTest :
                     <metadata>
                       <groupId>com.example</groupId>
                     </metadata>
-                    """.trimIndent()
+                    """
+                        .trimIndent()
                 )
 
             shouldThrow<IllegalStateException> { MavenMetadataXmlParser.parse(doc) }
@@ -89,7 +93,8 @@ class MavenMetadataXmlParserTest :
                       <groupId>com.example</groupId>
                       <artifactId>foo</artifactId>
                     </metadata>
-                    """.trimIndent()
+                    """
+                        .trimIndent()
                 )
 
             MavenMetadataXmlParser.parse(doc).artifactVersions shouldBe emptyList()

--- a/src/test/kotlin/io/cloudshiftdev/mavensync/MavenMetadataXmlTest.kt
+++ b/src/test/kotlin/io/cloudshiftdev/mavensync/MavenMetadataXmlTest.kt
@@ -35,7 +35,8 @@ class MavenMetadataXmlTest :
                 |    <lastUpdated>20240315083045</lastUpdated>
                 |  </versioning>
                 |</metadata>
-                |""".trimMargin()
+                |"""
+                    .trimMargin()
         }
 
         test("emits empty <versions> block when no versions") {

--- a/src/test/kotlin/io/cloudshiftdev/mavensync/MavenSyncEngineTest.kt
+++ b/src/test/kotlin/io/cloudshiftdev/mavensync/MavenSyncEngineTest.kt
@@ -6,20 +6,19 @@ import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import kotlin.time.Duration
 
-private fun defaultOptions(
-    transferChecksums: Boolean = false,
-    transferSignatures: Boolean = true,
-) = SyncOptions(
-    transferChecksums = transferChecksums,
-    transferSignatures = transferSignatures,
-    artifactConcurrency = 1,
-    crawlDelay = Duration.ZERO,
-    downloadDelay = Duration.ZERO,
-    paths = emptyList(),
-)
+private fun defaultOptions(transferChecksums: Boolean = false, transferSignatures: Boolean = true) =
+    SyncOptions(
+        transferChecksums = transferChecksums,
+        transferSignatures = transferSignatures,
+        artifactConcurrency = 1,
+        crawlDelay = Duration.ZERO,
+        downloadDelay = Duration.ZERO,
+        paths = emptyList(),
+    )
 
 private val group = Group("com.example")
 private val artifact = Artifact("foo")
+
 private fun coords(v: String) = Coordinates(group, artifact, ArtifactVersion(v))
 
 class MavenSyncEngineTest :
@@ -28,12 +27,20 @@ class MavenSyncEngineTest :
             val source = FakeMavenHttpRepository("source")
             val target = FakeMavenHttpRepository("target")
             target.seedMetadata(
-                ArtifactMetadata(group, artifact, listOf(ArtifactVersion("1.0"), ArtifactVersion("1.1")))
+                ArtifactMetadata(
+                    group,
+                    artifact,
+                    listOf(ArtifactVersion("1.0"), ArtifactVersion("1.1")),
+                )
             )
             val engine = MavenSyncEngine(source, target, defaultOptions())
 
             engine.handleArtifact(
-                ArtifactMetadata(group, artifact, listOf(ArtifactVersion("1.0"), ArtifactVersion("1.1")))
+                ArtifactMetadata(
+                    group,
+                    artifact,
+                    listOf(ArtifactVersion("1.0"), ArtifactVersion("1.1")),
+                )
             )
 
             source.listAssetCalls.shouldBeEmpty()
@@ -62,8 +69,9 @@ class MavenSyncEngineTest :
             )
 
             source.listAssetCalls.map { it.first } shouldContainExactlyInAnyOrder listOf(v11, v20)
-            source.copyCalls.map { (asset, repo) -> asset.coordinates to repo } shouldContainExactlyInAnyOrder
-                listOf(v11 to target, v20 to target)
+            source.copyCalls.map { (asset, repo) ->
+                asset.coordinates to repo
+            } shouldContainExactlyInAnyOrder listOf(v11 to target, v20 to target)
             target.releaseCalls shouldContainExactlyInAnyOrder listOf(v11, v20)
         }
 


### PR DESCRIPTION
## Summary

- CI run [25744526650](https://github.com/cloudshiftinc/maven-sync/actions/runs/25744526650) for #40 failed on `ktfmtCheckTest` for 7 newly-added test files; `main` is currently red. This PR reformats those files with `ktfmtFormat`.
- Order `precommit` so `ktfmtFormat` runs before `check` via `mustRunAfter` — previously `dependsOn("check", "ktfmtFormat")` allowed `check` to run first, which defeated the pairing.
- Add `CLAUDE.md` documenting the `./gradlew precommit` workflow for agents/contributors.

## Test plan

- [x] `./gradlew precommit` passes locally
- [x] `CI=true ./gradlew check` passes locally (simulates CI with `ktfmtCheck` enabled)
- [ ] PR `Build` job goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)