### PR TITLE
ci: only run publish step on push to main

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,4 +51,5 @@ jobs:
       run: './gradlew build --info --scan --stacktrace'
 
     - name: 'Publish'
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       run: './gradlew publish --info --stacktrace --no-configuration-cache'


### PR DESCRIPTION
## Summary
- Guards the Publish step in `.github/workflows/build.yaml` with `if: github.event_name == 'push' && github.ref == 'refs/heads/main'` so `./gradlew publish` only runs when commits land on `main`, not on every PR build.

## Test plan
- [ ] Open a PR: Build step runs, Publish step shows as skipped in the Actions UI.
- [ ] Merge to `main`: Build and Publish both run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)